### PR TITLE
Feature/docker and podman support

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,0 +1,5 @@
+CONTAINER_RUNTIME=  # podman or docker
+CONTAINER_DOMAIN=   # dns.podman or docker.internal
+VAULT_LICENSE=      # retrieve from https://www.hashicorp.com/products/vault/trial
+IPA_REALM=          # DNS.PODMAN or DOCKER.INTERNAL
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docker/terraform/*.lock.hcl
 docker/terraform/.terraform
 docker/prometheus_data/*
 docker/grafana_data/*
+.env

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The repository currently focuses on integration with the following authenticatio
 
 ## Prerequisites
 
+The playground runs with either docker or podman. The prerequisites slightly differ.
+
+### docker
+
 Install `docker-compose`, `kubectl` and `helm` on your local machine.
 
 Use v1 cgroups or the v1 compatibility mode on v2 systems for the FreeIPA container to work correctly, see:
@@ -23,6 +27,14 @@ To enable v1 compatibility set the kernel parameter:
 ```
 systemd.unified_cgroup_hierarchy=0
 ```
+
+### podman
+
+Install `podman-compose`, `containernetworking-plugins`, `kubectl` and `helm` on your local machine.
+
+
+*Tested with Fedora 36*
+
 
 ## Usage Instructions and FAQ
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,9 +5,9 @@ services:
       # https://github.com/keycloak/keycloak-containers#getting-started
       image: quay.io/keycloak/keycloak:legacy
       container_name: keycloak
-      hostname: keycloak.identity.net
+      hostname: "keycloak.${CONTAINER_DOMAIN}"
       networks:
-        - identity.net
+        - vault-playground
       environment:
         DB_VENDOR: POSTGRES
         DB_ADDR: keycloak-postgres
@@ -22,11 +22,11 @@ services:
       depends_on:
         - keycloak-postgres
   keycloak-postgres:
-      image: postgres
+      image: docker.io/library/postgres
       container_name: keycloak-postgres
-      hostname: keycloak-postgres.identity.net
+      hostname: "keycloak-postgres.${CONTAINER_DOMAIN}"
       networks:
-        - identity.net
+        - vault-playground
       volumes:
         - ./docker/keycloak-postgres:/var/lib/postgresql/data:Z
       environment:
@@ -35,15 +35,15 @@ services:
         POSTGRES_PASSWORD: password
 
   ipa:
-    image: freeipa/freeipa-server:centos-8-4.9.6
-    command: ipa-server-install -U -r IDENTITY.NET --no-ntp
+    image: docker.io/freeipa/freeipa-server:centos-8-4.9.6
+    command: "ipa-server-install -U -r ${IPA_REALM} --no-ntp"
     environment:
       PASSWORD: Secret123
     container_name: ipa
     # Container needs to be invoked with fully-qualified hostname
-    hostname: ipa.identity.net
+    hostname: "ipa.${CONTAINER_DOMAIN}"
     networks:
-      - identity.net
+      - vault-playground
     volumes:
       - ./docker/ipa:/data:Z
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -51,13 +51,13 @@ services:
       - net.ipv6.conf.all.disable_ipv6=0
 
   vault:
-    image: hashicorp/vault-enterprise:latest
+    image: docker.io/hashicorp/vault-enterprise:latest
     container_name: vault
-    hostname: vault.identity.net
+    hostname: "vault.${CONTAINER_DOMAIN}"
     cap_add:
       - IPC_LOCK
     networks:
-      - identity.net
+      - vault-playground
     command: server
     volumes:
       - ./docker/vault/config:/vault/config:Z
@@ -78,17 +78,18 @@ services:
       context: ./terraform-dockerfile
       dockerfile: Dockerfile
     container_name: terraform
-    hostname: terraform.identity.net
+    hostname: "terraform.${CONTAINER_DOMAIN}"
     networks:
-      - identity.net
+      - vault-playground
     # remove state from old Vault dev mode, init, re-apply and leave running for debugging purposes
     entrypoint: /bin/sh -c 'terraform init && terraform apply -auto-approve'
     working_dir: "/terraform"
     environment:
       # - TF_LOG=debug
-      - VAULT_ADDR=http://vault.identity.net:8200
+      - VAULT_ADDR=http://vault.${CONTAINER_DOMAIN}:8200
       - VAULT_TOKEN=root
       - CHECKPOINT_DISABLE=true
+      - TF_VAR_container_domain=${CONTAINER_DOMAIN}
     volumes:
       - ./docker/terraform:/terraform:Z
       - ./docker/k3s/output:/root/.kube:Z
@@ -98,11 +99,11 @@ services:
 
   k3s-server:
     # https://github.com/k3s-io/k3s/blob/master/docker-compose.yml
-    image: "rancher/k3s:${K3S_VERSION:-latest}"
+    image: "docker.io/rancher/k3s:${K3S_VERSION:-latest}"
     container_name: k3s-server
-    hostname: k3s-server.identity.net
+    hostname: "k3s-server.${CONTAINER_DOMAIN}"
     networks:
-      - identity.net
+      - vault-playground
     command: server
     tmpfs:
       - /run
@@ -129,11 +130,11 @@ services:
       - 6443:6443 # Kubernetes API Server
 
   grafana:
-    image: grafana/grafana:latest
+    image: docker.io/grafana/grafana:latest
     container_name: grafana
-    hostname: grafana.identity.net
+    hostname: "grafana.${CONTAINER_DOMAIN}"
     networks:
-      - identity.net
+      - vault-playground
     ports:
       - 3000:3000
     environment:
@@ -144,11 +145,11 @@ services:
       - ./docker/grafana_dashboards:/var/lib/grafana/dashboards:Z
 
   prometheus:
-    image: prom/prometheus:latest
+    image: docker.io/prom/prometheus:latest
     container_name: prometheus
-    hostname: prometheus.identity.net
+    hostname: "prometheus.${CONTAINER_DOMAIN}"
     networks:
-      - identity.net
+      - vault-playground
     volumes:
       - ./docker/prometheus_etc/prometheus.yml:/etc/prometheus/prometheus.yml:Z
       - ./docker/prometheus_etc/vault_rules.yml:/etc/prometheus/vault_rules.yml:Z
@@ -160,4 +161,4 @@ services:
       - 9090:9090
 
 networks:
-  identity.net:
+  vault-playground:

--- a/docker/grafana_dashboards/vault-identity-demo.json
+++ b/docker/grafana_dashboards/vault-identity-demo.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "description": "Demo dashboard for Vault Identity Net",
+  "description": "Demo dashboard for Vault",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -973,7 +973,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Vault Identity Net",
+  "title": "Vault Demo",
   "uid": "dQwRshe7z",
   "version": 1,
   "weekStart": ""

--- a/docker/terraform/scripts/get-cacerts.sh
+++ b/docker/terraform/scripts/get-cacerts.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-CACERTS=$(curl -ks "https://k3s-server.identity.net:6443/cacerts")
+CACERTS=$(curl -ks "https://k3s-server.$1:6443/cacerts")
 jq -n --arg cacerts "$CACERTS" '{"cacerts":$cacerts}'

--- a/docker/terraform/scripts/get-k8s-auth-delegator-sa-token.sh
+++ b/docker/terraform/scripts/get-k8s-auth-delegator-sa-token.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Set K3s server
-sed -i 's/127.0.0.1/k3s-server.identity.net/g' /root/.kube/config
+sed -i "s/127.0.0.1/k3s-server.$1/g" /root/.kube/config
 
 # Get Token Reviewer JWT
 TOKEN=$(

--- a/docker/terraform/variables.tf
+++ b/docker/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable "container_domain" {
+  type = string
+}

--- a/docker/terraform/vault-auth-kubernetes.tf
+++ b/docker/terraform/vault-auth-kubernetes.tf
@@ -1,8 +1,8 @@
 data "external" "cacerts" {
-  program = ["sh", "${path.root}/scripts/get-cacerts.sh"]
+  program = ["sh", "${path.root}/scripts/get-cacerts.sh", "${var.container_domain}"]
 }
 data "external" "auth_delegator_sa_token" {
-  program = ["sh", "${path.root}/scripts/get-k8s-auth-delegator-sa-token.sh"]
+  program = ["sh", "${path.root}/scripts/get-k8s-auth-delegator-sa-token.sh", "${var.container_domain}"]
 }
 
 resource "vault_auth_backend" "kubernetes" {
@@ -11,7 +11,7 @@ resource "vault_auth_backend" "kubernetes" {
 
 resource "vault_kubernetes_auth_backend_config" "kubernetes" {
   backend            = vault_auth_backend.kubernetes.path
-  kubernetes_host    = "https://k3s-server.identity.net:6443"
+  kubernetes_host    = "https://k3s-server.${var.container_domain}:6443"
   kubernetes_ca_cert = data.external.cacerts.result.cacerts
   issuer             = "https://kubernetes.default.svc.cluster.local"
   # token_reviewer_jwt = data.external.auth_delegator_sa_token.result.token

--- a/docker/terraform/vault-auth-ldap-oidc.tf
+++ b/docker/terraform/vault-auth-ldap-oidc.tf
@@ -3,7 +3,7 @@
 # - https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/ldap_auth_backend
 resource "vault_ldap_auth_backend" "ldap" {
   path         = "ldap"
-  url          = "ldaps://ipa.identity.net"
+  url          = "ldaps://ipa.${var.container_domain}"
   insecure_tls = true
   userdn       = "cn=users,cn=accounts,dc=identity,dc=net"
   userattr     = "uid"
@@ -20,7 +20,7 @@ resource "vault_jwt_auth_backend" "oidc" {
   type         = "oidc"
   default_role = "default"
   # https://www.keycloak.org/docs/latest/securing_apps
-  oidc_discovery_url = "http://keycloak.identity.net:8080/auth/realms/${keycloak_realm.realm.realm}"
+  oidc_discovery_url = "http://keycloak.${var.container_domain}:8080/auth/realms/${keycloak_realm.realm.realm}"
   oidc_client_id     = keycloak_openid_client.openid_client.client_id
   oidc_client_secret = keycloak_openid_client.openid_client.client_secret
 }
@@ -34,7 +34,7 @@ resource "vault_jwt_auth_backend_role" "keycloak" {
   role_type    = "oidc"
   # https://www.vaultproject.io/docs/auth/jwt#redirect-uris
   allowed_redirect_uris = [
-    "http://vault.identity.net:8200/ui/vault/auth/oidc/oidc/callback",
+    "http://vault.${var.container_domain}:8200/ui/vault/auth/oidc/oidc/callback",
     "http://localhost:8250/oidc/callback"
   ]
   # verbose_oidc_logging = true

--- a/scripts/provision-k3s.sh
+++ b/scripts/provision-k3s.sh
@@ -16,7 +16,7 @@ APP_NAMESPACE=vault-app
 APP_SERVICEACCOUNT=vault-kv
 # Define variables regarding the secret for the test Pod
 SECRETPROVIDERCLASS_NAME=vault-secret
-VAULT_ADDR="http://vault.identity.net:8200"
+VAULT_ADDR="http://vault.${CONTAINER_DOMAIN}:8200"
 
 # Patch CoreDNS to resolve the Vault Docker container name
 # https://coredns.io/2017/06/08/how-queries-are-processed-in-coredns
@@ -32,7 +32,7 @@ data:
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
         }
-        file /etc/coredns/identity.db identity.net
+        file /etc/coredns/identity.db ${CONTAINER_DOMAIN} 
         hosts /etc/coredns/NodeHosts {
           ttl 60
           reload 15s
@@ -46,8 +46,8 @@ data:
         loadbalance
     }
   identity.db: |
-    identity.net.               IN      SOA     ns.identity.net. hostmaster.identity.net. 2021102901 7200 3600 1209600 3600
-    vault.identity.net.         IN      A       $VAULT_IP
+    ${CONTAINER_DOMAIN}.               IN      SOA     ns.${CONTAINER_DOMAIN}. hostmaster.${CONTAINER_DOMAIN}. 2021102901 7200 3600 1209600 3600
+    vault.${CONTAINER_DOMAIN}.         IN      A       $VAULT_IP
 EOF
 )"
 

--- a/scripts/provision-ldap.sh
+++ b/scripts/provision-ldap.sh
@@ -4,9 +4,14 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
+# get domain name
+IPA_DOMAIN=$(dnsdomainname)
+DC1=${IPA_DOMAIN/.*/}
+DC2=${IPA_DOMAIN/*./}
+
 # Create testgroup ldif
 cat << EOF > group.ldif
-dn: cn=testgroup,cn=groups,cn=accounts,dc=identity,dc=net
+dn: cn=testgroup,cn=groups,cn=accounts,dc=${DC1},dc=${DC2}
 cn: testgroup
 objectClass: top
 objectClass: groupofnames
@@ -15,12 +20,12 @@ objectClass: ipausergroup
 objectClass: ipaobject
 objectClass: posixgroup
 gidNumber: 93800001
-member: uid=test,cn=users,cn=accounts,dc=identity,dc=net
+member: uid=test,cn=users,cn=accounts,dc=${DC1},dc=${DC2}
 EOF
 
 # Create test user ldif
 cat << EOF > user.ldif
-dn: uid=test,cn=users,cn=accounts,dc=identity,dc=net
+dn: uid=test,cn=users,cn=accounts,dc=${DC1},dc=${DC2}
 givenName: Max
 sn: Muster
 uid: test
@@ -28,7 +33,7 @@ cn: Max Muster
 displayName: Max Muster
 initials: MM
 gecos: Max Muster
-krbPrincipalName: test@IDENTITY.NET
+krbPrincipalName: test@${DC1^^}.${DC2^^}
 objectClass: top
 objectClass: person
 objectClass: organizationalperson
@@ -43,18 +48,18 @@ objectClass: ipaSshGroupOfPubKeys
 objectClass: mepOriginEntry
 loginShell: /bin/sh
 homeDirectory: /home/test
-mail: test@identity.net
-krbCanonicalName: test@IDENTITY.NET
+mail: test@${DC1}.${DC2}
+krbCanonicalName: test@${DC1^^}.${DC2^^}
 userPassword: test
 uidNumber: 93800003
 gidNumber: 93800003
-memberOf: cn=ipausers,cn=groups,cn=accounts,dc=identity,dc=net
-memberOf: cn=testgroup,cn=groups,cn=accounts,dc=identity,dc=net
+memberOf: cn=ipausers,cn=groups,cn=accounts,dc=${DC1},dc=${DC2}
+memberOf: cn=testgroup,cn=groups,cn=accounts,dc=${DC1},dc=${DC2}
 EOF
 
 # Create test user for KV access
 cat << EOF > kv-writer.ldif
-dn: uid=kv-writer,cn=users,cn=accounts,dc=identity,dc=net
+dn: uid=kv-writer,cn=users,cn=accounts,dc=${DC1},dc=${DC2}
 givenName: KV
 sn: Writer
 uid: kv-writer
@@ -62,7 +67,7 @@ cn: KV Writer
 displayName: KV Writer
 initials: KW
 gecos: KV Writer
-krbPrincipalName: kv-writer@IDENTITY.NET
+krbPrincipalName: kv-writer@${DC1^^}.${DC2^^}
 objectClass: top
 objectClass: person
 objectClass: organizationalperson
@@ -77,18 +82,18 @@ objectClass: ipaSshGroupOfPubKeys
 objectClass: mepOriginEntry
 loginShell: /bin/sh
 homeDirectory: /home/kv-writer
-mail: kv-writer@identity.net
-krbCanonicalName: kv-writer@IDENTITY.NET
+mail: kv-writer@${DC1}.${DC2}
+krbCanonicalName: kv-writer@${DC1^^}.${DC2^^}
 userPassword: kv-writer
 uidNumber: 1997000001
 gidNumber: 1997000001
 krbPasswordExpiration: 20211027132312Z
 krbLastPwdChange: 20211027132312Z
 krbExtraData:: AALAUnlhcm9vdC9hZG1pbkBJREVOVElUWS5ORVQA
-memberOf: cn=ipausers,cn=groups,cn=accounts,dc=identity,dc=net
+memberOf: cn=ipausers,cn=groups,cn=accounts,dc=${DC1},dc=${DC2}
 EOF
 
 # Apply the ldifs
-ldapadd -x -w Secret123 -D uid=admin,cn=users,cn=accounts,dc=identity,dc=net -f group.ldif
-ldapadd -x -w Secret123 -D uid=admin,cn=users,cn=accounts,dc=identity,dc=net -f user.ldif
-ldapadd -x -w Secret123 -D uid=admin,cn=users,cn=accounts,dc=identity,dc=net -f kv-writer.ldif
+ldapadd -x -w Secret123 -D uid=admin,cn=users,cn=accounts,dc=${DC1},dc=${DC2} -f group.ldif
+ldapadd -x -w Secret123 -D uid=admin,cn=users,cn=accounts,dc=${DC1},dc=${DC2} -f user.ldif
+ldapadd -x -w Secret123 -D uid=admin,cn=users,cn=accounts,dc=${DC1},dc=${DC2} -f kv-writer.ldif


### PR DESCRIPTION
Since I'm using podman only, I'd love to see it supported. That's what this PR is all about. I added some dynamics so that if CONTAINER_RUNTIME=podman is defined, It'll use CONTAINER_DOMAIN=dns.podman everywhere and if CONTAINER_RUNTIME=docker, then CONTAINER_DOMAIN=docker.internal. Using the docker/podman default domains and the dns service facilitates things. 

@Xelef2000 and @in0rdr , please test this through with docker.