### PR TITLE
JWT Authentication with keycloak/ipa as auth backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docker/terraform/.terraform
 docker/prometheus_data/*
 docker/grafana_data/*
 .env
+jwt.json

--- a/USAGE.md
+++ b/USAGE.md
@@ -277,21 +277,31 @@ The access is only granted for LDAP logins, because the Entity Alias is connecte
 This playground also has a JWT authentication backend available. Configuration is basically the same as for the OIDC authentication backend. The difference is that a token fetched from keycloak can be used directly to log into Vault.
 
 Fetch token
-```
+```bash
 username=test
 password=test
-curl -L -X POST "http://keycloak.${CONTAINER_DOMAIN}:8080/auth/realms/${CONTAINER_DOMAIN//\./-}/protocol/openid-connect/token" \
+curl -s -L -X POST "http://keycloak.${CONTAINER_DOMAIN}:8080/auth/realms/${CONTAINER_DOMAIN//\./-}/protocol/openid-connect/token" \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 --data-urlencode 'client_id=hashicorp-vault-jwt' \
 --data-urlencode 'grant_type=password' \
 --data-urlencode 'scope=openid' \
 --data-urlencode "username=${username}" \
---data-urlencode "password=${username}"
+--data-urlencode "password=${password}" > jwt.json
 ``` 
 
-Login with "access_token"
-```
-vault write auth/jwt/login jwt=ey...
+Vault login with JWT `access_token`:
+```bash
+vault write auth/jwt/login jwt=$(cat jwt.json | jq -r '.access_token')
+Key                  Value
+---                  -----
+token                hvs.CA...
+token_accessor       ***
+token_duration       768h
+token_renewable      true
+token_policies       ["default"]
+identity_policies    ["tenant2_admin" "tenant3_admin" "tenant_admin"]
+policies             ["default" "tenant2_admin" "tenant3_admin" "tenant_admin"]
+token_meta_role      default
 ```
 
 ## How to Grant Role based Access for AppRoles?

--- a/docker/terraform/keycloak.tf
+++ b/docker/terraform/keycloak.tf
@@ -90,7 +90,7 @@ resource "keycloak_openid_client" "jwt_client" {
 resource "keycloak_generic_client_protocol_mapper" "openid_client_groups" {
   realm_id        = keycloak_realm.realm.id
   client_id       = keycloak_openid_client.openid_client.id
-  name            = "groups"
+  name            = "groups-vault-oidc"
   protocol        = "openid-connect"
   protocol_mapper = "oidc-group-membership-mapper"
   config = {
@@ -105,7 +105,7 @@ resource "keycloak_generic_client_protocol_mapper" "openid_client_groups" {
 resource "keycloak_generic_client_protocol_mapper" "jwt_client_groups" {
   realm_id        = keycloak_realm.realm.id
   client_id       = keycloak_openid_client.jwt_client.id
-  name            = "groups"
+  name            = "groups-vault-jwt"
   protocol        = "openid-connect"
   protocol_mapper = "oidc-group-membership-mapper"
   config = {

--- a/docker/terraform/keycloak.tf
+++ b/docker/terraform/keycloak.tf
@@ -68,7 +68,26 @@ resource "keycloak_openid_client" "openid_client" {
     "http://vault.${var.container_domain}:8200/ui/vault/auth/oidc/oidc/callback"
   ]
 }
-resource "keycloak_generic_client_protocol_mapper" "groups" {
+
+# Add Vault as OpenID Connect Client for JWT
+resource "keycloak_openid_client" "jwt_client" {
+  realm_id  = keycloak_realm.realm.id
+  client_id = "hashicorp-vault-jwt"
+
+  name    = "HashiCorp Vault vault.${var.container_domain}"
+  enabled = true
+
+  access_type           = "PUBLIC"
+  standard_flow_enabled = true
+  direct_access_grants_enabled = true
+
+  valid_redirect_uris = [
+    "http://localhost:8250/jwt/callback",
+    "http://vault.${var.container_domain}:8200/ui/vault/auth/jwt/oidc/callback"
+  ]
+}
+
+resource "keycloak_generic_client_protocol_mapper" "openid_client_groups" {
   realm_id        = keycloak_realm.realm.id
   client_id       = keycloak_openid_client.openid_client.id
   name            = "groups"
@@ -82,3 +101,19 @@ resource "keycloak_generic_client_protocol_mapper" "groups" {
     "userinfo.token.claim" = "true"
   }
 }
+
+resource "keycloak_generic_client_protocol_mapper" "jwt_client_groups" {
+  realm_id        = keycloak_realm.realm.id
+  client_id       = keycloak_openid_client.jwt_client.id
+  name            = "groups"
+  protocol        = "openid-connect"
+  protocol_mapper = "oidc-group-membership-mapper"
+  config = {
+    "access.token.claim"   = "true"
+    "id.token.claim"       = "true"
+    "claim.name"           = "groups"
+    "full.path"            = "false"
+    "userinfo.token.claim" = "true"
+  }
+}
+

--- a/docker/terraform/vault.tf
+++ b/docker/terraform/vault.tf
@@ -22,17 +22,13 @@ resource "vault_namespace" "namespace" {
 }
 
 # Authorization on namespaces
-# TODO: RENAME MODULE
 module "groups" {
   for_each   = local.groups
   source     = "./groups"
   namespaces = each.value.namespaces
   group      = each.key
   metadata   = each.value.metadata
-  depends_on = [vault_jwt_auth_backend.oidc, vault_namespace.namespace]
-  # admin_groups   = jsonencode(local.groups_to_namespaces)
-  # TODO: add same logic for supplemental_groups admin_groups
-  #supplemental_groups = local.supplemental_groups
+  depends_on = [vault_jwt_auth_backend.oidc, vault_jwt_auth_backend.jwt, vault_namespace.namespace]
 }
 
 # KV engine inside the namespace


### PR DESCRIPTION
One can authenticate to Vault using a token fetched from keycloak. See Usage,md for more information. User/group/policy mapping is the same as in ldap and oidc. Looking forward to feedback :)