### PR TITLE
Added script to automatically add domain names to /etc/hosts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vault-keys.json
 *.hclic
+backup
 docker/ipa
 docker/k3s
 docker/keycloak-postgres

--- a/01-start.sh
+++ b/01-start.sh
@@ -2,6 +2,9 @@
 
 # get container runntime
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+# the .env file will overwrite the environment variables
+test -f .env && source .env
+
 
 # message
 MESSAGE="This is a development environment and should not be used in production!"

--- a/02-add-to-hosts-file.sh
+++ b/02-add-to-hosts-file.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# get container runntime domain
+CONTAINER_DOMAIN=${CONTAINER_DOMAIN:-docker}
+test -f .env && source .env
+
+# backup the hosts file
+mkdir -p backup
+cp /etc/hosts backup/hosts
+
+# cleanup the hosts file
+
+sudo sed -i '' /etc/hosts 
+sudo sed -i '/### vault playground start ###/,/### vault playground end ###/d' /etc/hosts 
+
+
+echo -e "### vault playground start ###" | sudo tee -a /etc/hosts
+echo -e "#the cleanup script will delete everything between this tags" | sudo tee -a /etc/hosts
+
+
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} ipa.${CONTAINER_DOMAIN}{{end}}" ipa) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} keycloak.${CONTAINER_DOMAIN}{{end}}" keycloak) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} vault.${CONTAINER_DOMAIN}{{end}}" vault) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} k3s-server.${CONTAINER_DOMAIN}{{end}}" k3s-server) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} grafana.${CONTAINER_DOMAIN}{{end}}" grafana) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} prometheus.${CONTAINER_DOMAIN}{{end}}" prometheus) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} es.${CONTAINER_DOMAIN}{{end}}" es) | sudo tee -a /etc/hosts
+echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} kibana.${CONTAINER_DOMAIN}{{end}}" kibana) | sudo tee -a /etc/hosts
+
+echo -e "### vault playground end ###" | sudo tee -a /etc/hosts

--- a/03-stop.sh
+++ b/03-stop.sh
@@ -2,6 +2,8 @@
 
 # get container runntime
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+# the .env file will overwrite the environment variables
+test -f .env && source .env
 
 # stop containers
 $CONTAINER_RUNTIME-compose down

--- a/04-cleanup.sh
+++ b/04-cleanup.sh
@@ -7,7 +7,7 @@ then
 fi
 
 echo "Stopping and removing containers"
-./stop.sh
+./03-stop.sh
 
 # cleanup the docker data
 sudo rm -rf docker/{ipa,k3s,keycloak-postgres,kibana,es}
@@ -23,3 +23,7 @@ fi
 sudo rm -rf docker/terraform/*.tfstate*
 sudo rm -rf docker/terraform/.terraform.lock.hcl
 sudo rm -rf docker/terraform/.terraform
+
+# cleanup the hosts file
+sudo sed -i '/### vault playground start ###/,/### vault playground end ###/d' /etc/hosts 
+echo "If /etc/hosts file got cleanup incorrectly, please restore it from backup/hosts"

--- a/USAGE.md
+++ b/USAGE.md
@@ -82,8 +82,7 @@ nmcli c mod ${CONTAINER_RUNTIME_IF} ipv4.dns-search ${CONTAINER_DOMAIN}
 ```
 
 ### Option 2: Static configuration using hosts file
-Add a static A record for the container hosting FreeIPA, Keycloak and Vault. Alternatively, adjust your `/etc/hosts` file accordingly:
-
+You can add a static record for every container to your `/etc/hosts` file with the 02-add-hosts.sh script.
 ```bash
 sudo ./02-add-hosts.sh
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -85,17 +85,11 @@ nmcli c mod ${CONTAINER_RUNTIME_IF} ipv4.dns-search ${CONTAINER_DOMAIN}
 Add a static A record for the container hosting FreeIPA, Keycloak and Vault. Alternatively, adjust your `/etc/hosts` file accordingly:
 
 ```bash
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} ipa.${CONTAINER_DOMAIN}{{end}}" ipa) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} keycloak.${CONTAINER_DOMAIN}{{end}}" keycloak) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} vault.${CONTAINER_DOMAIN}{{end}}" vault) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} k3s-server.${CONTAINER_DOMAIN}{{end}}" k3s-server) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} grafana.${CONTAINER_DOMAIN}{{end}}" grafana) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} prometheus.${CONTAINER_DOMAIN}{{end}}" prometheus) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} es.${CONTAINER_DOMAIN}{{end}}" es) | sudo tee -a /etc/hosts
-echo -e $(sudo -E ${CONTAINER_RUNTIME} inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} kibana.${CONTAINER_DOMAIN}{{end}}" kibana) | sudo tee -a /etc/hosts
+sudo ./02-add-hosts.sh
 ```
-
-You need to clean up your `/etc/hosts` after successive runs to remove conflicting entries from previous runs.
+This will add all the necessary entries to your `/etc/hosts` file between 2 Tags. Old entries will be replaced.
+The 04-clean-up.sh script also will remove the entries.
+If something would go wrong with the cleanup, a backup of the original `/etc/hosts` file will be created in `./backup`.
 
 ## 5. Provision Test Identity/Group Data
 


### PR DESCRIPTION
Added the script 02-add-to-hosts-file.sh which will add all the necessary entries to the /etc/hosts file between the tags `### vault playground start ###` and `### vault playground end ###`.
Old entries will be replaced.
The cleanup script will also remove those entries.

The script will also create a backup of the /etc/hosts file in the vault-playground/backup directory.

All the scripts 01 - 04 will now also load the .env file.