### PR TITLE
Fixing podman support

### DIFF
--- a/01-start.sh
+++ b/01-start.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 
-# get container runntime
-CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
-# the .env file will overwrite the environment variables
-test -f .env && source .env
-
-
 # message
 MESSAGE="This is a development environment and should not be used in production!"
 RED='\033[0;31m'
 NC='\033[0m' 
-
-
 
 # check if cowsay is installed
 if ! command -v cowsay &> /dev/null
@@ -20,6 +12,33 @@ then
 else
     echo -e "${RED}$(cowsay -f stegosaurus ${MESSAGE})${NC}"
 fi
+
+
+# get container runntime
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+# the .env file will overwrite the environment variables
+test -f .env && source .env
+
+
+#adjust the docker-compose.yml file and vault config
+if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    sudo sed -i 's/statsd_address =.*$/statsd_address = '\"host.containers.internal:8125\"'/g' ./docker/vault/config/statsd-telemetry.hcl
+    sed -i 's/extra_hosts:.*$/# extra_hosts:/g' docker-compose.yaml
+    sed -i 's/  - host.docker.internal:host-gateway.*$/#  - host.docker.internal:host-gateway/g' docker-compose.yaml
+fi
+else if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+    sudo sed -i 's/statsd_address =.*$/statsd_address = '\"host.docker.internal:8125\"'/g' ./docker/vault/config/statsd-telemetry.hcl
+    sed -i 's/# extra_hosts:.*$/extra_hosts:/g' docker-compose.yaml
+    sed -i 's/#  - host.docker.internal:host-gateway.*$/  - host.docker.internal:host-gateway/g' docker-compose.yaml
+fi
+
+
+# manually build the terraform image
+if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    sudo podman build --network=host ./terraform-dockerfile
+fi
+
+
 
 # run containers
 $CONTAINER_RUNTIME-compose up -d

--- a/01-start.sh
+++ b/01-start.sh
@@ -25,8 +25,7 @@ if [ "$CONTAINER_RUNTIME" == "podman" ]; then
     sudo sed -i 's/statsd_address =.*$/statsd_address = '\"host.containers.internal:8125\"'/g' ./docker/vault/config/statsd-telemetry.hcl
     sed -i 's/extra_hosts:.*$/# extra_hosts:/g' docker-compose.yaml
     sed -i 's/  - host.docker.internal:host-gateway.*$/#  - host.docker.internal:host-gateway/g' docker-compose.yaml
-fi
-else if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+elif [ "$CONTAINER_RUNTIME" == "docker" ]; then
     sudo sed -i 's/statsd_address =.*$/statsd_address = '\"host.docker.internal:8125\"'/g' ./docker/vault/config/statsd-telemetry.hcl
     sed -i 's/# extra_hosts:.*$/extra_hosts:/g' docker-compose.yaml
     sed -i 's/#  - host.docker.internal:host-gateway.*$/  - host.docker.internal:host-gateway/g' docker-compose.yaml

--- a/USAGE.md
+++ b/USAGE.md
@@ -45,6 +45,11 @@ echo IPA_REALM=${CONTAINER_DOMAIN^^} >> .env
 
 ## 3. Start Containers
 
+The 01-start.sh will use docker or podman-compose to start the containers. 
+The script is required for podman because it patches the docker-compose file and the vault configuration file in ` ./docker/vault/config/statsd-telemetry.hcl`.
+It is also required when switching from podman to docker or vice versa.
+
+
 Start FreeIPA, Keycloak, Vault and K3s:
 ```bash
 sudo 01-start.sh
@@ -144,11 +149,24 @@ Remove Terraform container and recreate with Vault Token from previous step:
 sudo ${CONTAINER_RUNTIME}-compose stop terraform
 sudo ${CONTAINER_RUNTIME}-compose up -d terraform
 ```
+Check Terraform container logs:
+```bash
+sudo ${CONTAINER_RUNTIME}-compose logs -f terraform
+```
 
 You might need to unseal Vault again (see above). Then start Terraform. Can be started repeatedly:
 ```bash
 sudo ${CONTAINER_RUNTIME}-compose start terraform
 ```
+
+
+Or stop and delete the container manually:
+```bash
+sudo ${CONTAINER_RUNTIME}-compose stop terraform
+sudo ${CONTAINER_RUNTIME}-compose rm -f terraform
+sudo ${CONTAINER_RUNTIME}-compose up -d terraform
+```
+
 
 Provision the 389 directory with the test users and groups:
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -52,7 +52,7 @@ It is also required when switching from podman to docker or vice versa.
 
 Start FreeIPA, Keycloak, Vault and K3s:
 ```bash
-sudo 01-start.sh
+sudo ./01-start.sh
 ```
 
 ## 4. Setup Resolution of Domain Names

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       depends_on:
         - keycloak-postgres
   keycloak-postgres:
-      image: docker.io/library/postgres
+      image: docker.io/library/postgres:14.0-alpine
       container_name: keycloak-postgres
       hostname: "keycloak-postgres.${CONTAINER_DOMAIN}"
       networks:
@@ -171,7 +171,7 @@ services:
     networks:
       - vault-playground
     volumes:
-      - ./docker/es:/usr/share/elasticsearch/data:Z
+      - ./docker/es:/usr/share/elasticsearch/data:Z,U
     ports:
       - 9200:9200
     environment:
@@ -186,7 +186,7 @@ services:
     networks:
       - vault-playground
     volumes:
-      - ./docker/kibana:/usr/share/kibana/data:Z
+      - ./docker/kibana:/usr/share/kibana/data:Z,U
     ports:
       - 5601:5601
     environment:
@@ -200,8 +200,8 @@ services:
     networks:
       - vault-playground
     volumes:
-      - ./docker/metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml
-      - ./docker/metricbeat/statsd.yml:/usr/share/metricbeat/modules.d/statsd.yml
+      - ./docker/metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:Z,U
+      - ./docker/metricbeat/statsd.yml:/usr/share/metricbeat/modules.d/statsd.yml:Z,U
     ports:
       - 8125:8125/udp
     environment:

--- a/scripts/provision-k3s.sh
+++ b/scripts/provision-k3s.sh
@@ -4,6 +4,13 @@
 set -o nounset
 # set -o xtrace
 
+# load container runtime environment variables
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+CONTAINER_DOMAIN=${CONTAINER_DOMAIN:-docker}
+
+test -f .env && source .env
+
+
 # Use kubeconfig of the k3s container
 export KUBECONFIG=$PWD/docker/k3s/output/kubeconfig.yaml
 
@@ -20,7 +27,7 @@ VAULT_ADDR="http://vault.${CONTAINER_DOMAIN}:8200"
 
 # Patch CoreDNS to resolve the Vault Docker container name
 # https://coredns.io/2017/06/08/how-queries-are-processed-in-coredns
-VAULT_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' vault)
+VAULT_IP=$(${CONTAINER_RUNTIME} inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' vault)
 kubectl patch configmap/coredns -n kube-system --patch "$(cat <<EOF
 data:
   Corefile: |


### PR DESCRIPTION
Kibana and Elastic search didn't work with podman because of filesystem permission issues on the mounted volumes.
This was fixed by forcing a chown on the volume with the :U flag.

Podman had problems building the terraform container.
This is now done in 01-start.sh before starting the docker-compose file, if the container runtime is podman.

A missing image tag keycloak-postgres broke keycloak, the tag 14.0-alpine was added.

scripts/provision-k3s.sh had the docker domain hardcoded for the vault address, it now uses the environment variable or the .env file.

The option ` - host.docker.internal:host-gateway` does not exist on podman podman uses host.container.internal.
01-start.sh will detect the container runtime and adjust the docker-compose file and `./docker/vault/config/statsd-telemetry.hcl` accordingly.

The USAGE.md was updated to reflect those changes.